### PR TITLE
Fix Card path resolution

### DIFF
--- a/quartz/components/Card
+++ b/quartz/components/Card
@@ -1,12 +1,14 @@
 import { QuartzComponentProps } from "../types"
-import { pathToRoot } from "../util/path"
+import { FullSlug, resolveRelative } from "../util/path"
 
 export const Card = ({ file }: QuartzComponentProps) => {
   if (!file) return null // Defensive: bail if file is missing
 
   const title = file.frontmatter?.title || file.slug || ""
   const description = file.frontmatter?.description || ""
-  const link = file.slug ? pathToRoot(file.slug) : "#"
+  const link = file.slug
+    ? resolveRelative("index" as FullSlug, file.slug as FullSlug)
+    : "#"
 
   return (
     <a className="card" href={link}>

--- a/quartz/layouts/components/Card.tsx
+++ b/quartz/layouts/components/Card.tsx
@@ -1,10 +1,10 @@
 import { QuartzComponentProps } from "../../types"
-import { pathToRoot } from "../../util/path"
+import { FullSlug, resolveRelative } from "../../util/path"
 
 export const Card = ({ file }: QuartzComponentProps) => {
   const title = file.frontmatter?.title || file.slug
   const description = file.frontmatter?.description || ""
-  const link = pathToRoot(file.slug)
+  const link = resolveRelative("index" as FullSlug, file.slug as FullSlug)
   return (
     <a class="card" href={link}>
       <div class="card-content">


### PR DESCRIPTION
## Summary
- update Card components to use `resolveRelative` instead of `pathToRoot`

## Testing
- `npm run test` *(fails: tsx not found)*
- `npm run check` *(fails: tsc errors)*
- `npm run docs` *(fails: missing `yargs`)*


------
https://chatgpt.com/codex/tasks/task_e_6845e482f0e0832082686262de43ecf0